### PR TITLE
Dependency update 20230822

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1688525511,
-        "narHash": "sha256-kfQFC2iIlN3RU4UXsVP/R52hd79XFAkJYzdEELqRWog=",
+        "lastModified": 1693268846,
+        "narHash": "sha256-w3yK1C6/JsBVvZRKnZw4HPBajYWpcA2BR3t13mfALzE=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "5aa5f0f9d461bd75af3a2520319a5e56e17c9399",
+        "rev": "5c8b2fe6bf30b858dce75809d0caf6ccbf1c9f0e",
         "type": "github"
       },
       "original": {

--- a/timeline.cabal
+++ b/timeline.cabal
@@ -29,11 +29,11 @@ common deps
   build-depends:
     , base                 >=4.14.3  && <4.19
     , containers           >=0.6.5   && <0.7
-    , hedgehog             >=1.1     && <1.4
+    , hedgehog             >=1.1     && <1.5
     , indexed-traversable  >=0.1.2   && <0.2
     , semigroupoids        >=5.3.7   && <6.1
     , template-haskell     >=2.16.0  && <2.21
-    , text                 >=1.2.4.1 && <2.1
+    , text                 ^>= 1.2.4.1 || ^>=2.0 && <2.2
     , th-compat            >=0.1.4   && <0.2
     , time                 >=1.9.3   && <1.13
 
@@ -56,16 +56,16 @@ test-suite tests
   build-tool-depends: tasty-discover:tasty-discover >=4.2 && <5.1
   build-depends:
     , base                 >=4.14.3    && <4.19
-    , bytestring           >=0.10      && <0.12
+    , bytestring           >=0.10      && <0.13
     , containers           >=0.6.5     && <0.7
     , hashable             ^>=1.4.2.0
-    , hedgehog             >=1.1       && <1.4
+    , hedgehog             >=1.1       && <1.5
     , indexed-traversable  ^>=0.1.2
     , tasty                ^>=1.4.3
     , tasty-golden         ^>=2.3.5
     , tasty-hedgehog       >=1.2.0.0
     , tasty-hunit          ^>=0.10.0.3
-    , text                 >=1.2.4.1   && <2.1
+    , text                 ^>= 1.2.4.1 || ^>=2.0 && <2.2
     , time                 >=1.9.3     && <1.13
     , timeline
     , transformers         >=0.5.6.2   && <0.6.2.0


### PR DESCRIPTION
I managed to update the `flake.lock` and cabal bounds and everything is building as it should.

Once merged, I'll update the metadata on Hackage.