### PR TITLE
20250624 Dependency update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1745889581,
-        "narHash": "sha256-HLegrUPqKcWe0V1ejF7quy/tNJi7lvznbeg2nUmlud8=",
+        "lastModified": 1750731092,
+        "narHash": "sha256-Fu4lFidcFBEoFaevUwf4Vkb3Jv+ZbPuN82NZCFEym8g=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "8237c1f5340bfdb932c03265110ca465f77d7d84",
+        "rev": "fbbc4fed2d812e8417857ffc9451d7c6f1242d43",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1750684550,
+        "narHash": "sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "fae816c55a75675f30d18c9cbdecc13b970d95d4",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745377448,
-        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "lastModified": 1750605355,
+        "narHash": "sha256-xT8cPLTxlktxI9vSdoBlAVK7dXgd8IK59j7ZwzkkhnI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "rev": "3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'bellroy-nix-foss':
    'github:bellroy/bellroy-nix-foss/8237c1f5340bfdb932c03265110ca465f77d7d84?narHash=sha256-HLegrUPqKcWe0V1ejF7quy/tNJi7lvznbeg2nUmlud8%3D' (2025-04-29)
  → 'github:bellroy/bellroy-nix-foss/fbbc4fed2d812e8417857ffc9451d7c6f1242d43?narHash=sha256-Fu4lFidcFBEoFaevUwf4Vkb3Jv%2BZbPuN82NZCFEym8g%3D' (2025-06-24)
• Updated input 'bellroy-nix-foss/git-hooks':
    'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82?narHash=sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco%3D' (2025-03-22)
  → 'github:cachix/git-hooks.nix/fae816c55a75675f30d18c9cbdecc13b970d95d4?narHash=sha256-uLtw0iF9mQ94L831NOlQLPX9wm0qzd5yim3rcwACEoM%3D' (2025-06-23)
• Updated input 'bellroy-nix-foss/nixpkgs':
    'github:NixOS/nixpkgs/507b63021ada5fee621b6ca371c4fca9ca46f52c?narHash=sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA%3D' (2025-04-23)
  → 'github:NixOS/nixpkgs/3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6?narHash=sha256-xT8cPLTxlktxI9vSdoBlAVK7dXgd8IK59j7ZwzkkhnI%3D' (2025-06-22)