### PR TITLE
Dependency Update 20260609

### DIFF
--- a/timeline.cabal
+++ b/timeline.cabal
@@ -19,9 +19,9 @@ tested-with:
   GHC ==8.10.7
    || ==9.2.8
    || ==9.4.8
-   || ==9.6.6
-   || ==9.8.2
-   || ==9.10.2
+   || ==9.6.7
+   || ==9.8.4
+   || ==9.10.3
    || ==9.12.2
 
 extra-doc-files:
@@ -41,7 +41,7 @@ common deps
     , hedgehog             >=1.1      && <1.8
     , indexed-traversable  >=0.1.2    && <0.2
     , text                 ^>=1.2.4.1 || ^>=2.0 || ^>=2.1
-    , time                 >=1.9.3    && <1.16
+    , time                 >=1.9.3    && <1.17
 
 library
   import:           deps
@@ -66,7 +66,7 @@ test-suite tests
   main-is:            Main.hs
   other-modules:      Data.TimelineTest
   default-language:   Haskell2010
-  build-tool-depends: tasty-discover:tasty-discover >=4.2 && <5.1
+  build-tool-depends: tasty-discover:tasty-discover >=4.2 && <5.3
   build-depends:
     , bytestring      >=0.10      && <0.13
     , hashable        ^>=1.4.2.0  || ^>=1.5
@@ -75,4 +75,4 @@ test-suite tests
     , tasty-hedgehog  >=1.2.0.0
     , tasty-hunit     ^>=0.10.0.3
     , timeline
-    , transformers    >=0.5.6.2   && <0.6.4
+    , transformers    >=0.5.6.2   && <0.7


### PR DESCRIPTION
- time: <1.16 -> <1.17 (admits latest 1.16; flagged by cabal outdated)
- tasty-discover: <5.1 -> <5.3 (admits latest 5.2.0)
- transformers: <0.6.4 -> <0.7 (conventional next-major bound)
- tested-with: bump GHC patch versions to match nixpkgs (9.6.7, 9.8.4, 9.10.3)

Builds and tests pass on GHC 9.10.3 and 9.12.2.